### PR TITLE
Add Rails 5 support, fix deprecations

### DIFF
--- a/lib/peek-active_resource/version.rb
+++ b/lib/peek-active_resource/version.rb
@@ -1,5 +1,5 @@
 module Peek
   module ActiveResource
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end

--- a/peek-active_resource.gemspec
+++ b/peek-active_resource.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'peek'
   spec.add_dependency 'activeresource'
-  spec.add_dependency 'atomic', '>= 1.0.0'
+  spec.add_dependency 'concurrent-ruby'
 end


### PR DESCRIPTION
Fixes https://github.com/gotmayonase/peek-active_resource/issues/1

- Replaces deprecated `atomic` gem with `concurrent-ruby`
- Replaces deprecated `alias_method_chain` with `.prepend(Module)`

Tested on Rails 5.1.3